### PR TITLE
Qitta取得機能のリファクタリングとカテゴリと紐づけ機能追加

### DIFF
--- a/src/app/Console/Commands/FetchQitta.php
+++ b/src/app/Console/Commands/FetchQitta.php
@@ -4,7 +4,7 @@ namespace App\Console\Commands;
 use Illuminate\Console\Command;
 use App\Services\ArticleFetcher\QiitaFetcher;
 
-class FetchArticles extends Command
+class FetchQitta extends Command
 {
     /**
      * The name and signature of the console command.
@@ -18,7 +18,7 @@ class FetchArticles extends Command
      *
      * @var string
      */
-    protected $description = 'Fetch articles from Qiita or Zenn';
+    protected $description = 'Fetch articles from Qiita';
 
     /**
      * Execute the console command.

--- a/src/app/Console/Commands/FetchQitta.php
+++ b/src/app/Console/Commands/FetchQitta.php
@@ -11,7 +11,7 @@ class FetchQitta extends Command
      *
      * @var string
      */
-    protected $signature = 'articles:fetch {target}';
+    protected $signature = 'fetch:qitta {type} {value?}';
 
     /**
      * The console command description.
@@ -27,27 +27,30 @@ class FetchQitta extends Command
      */
     public function handle(QiitaFetcher $qiita)
     {
-        $target = $this->argument('target');
+        $type = $this->argument('type');
+        $value = $this->argument('value');
 
-        switch ($target) {
-            case 'qiita:new':
-                [$new, $updated, $skipped] = $qiita->fetchNew();
+        switch ($type) {
+            case 'new':
+                [$new, $updated] = $qiita->fetchNew();
                 break;
-            case 'qiita:popular':
-                [$new, $updated, $skipped] = $qiita->fetchPopular();
+            case 'popular':
+                [$new, $updated] = $qiita->fetchPopular();
                 break;
-
-            case (str_starts_with($target, 'qiita:tag:')):
-                $tag = str_replace('qiita:tag:', '', $target);
-                [$new, $updated, $skipped] = $qiita->fetchByTag($tag);
+            case 'tag':
+                if (!$value) {
+                    $this->error('tag name requirad');
+                    return Command::FAILURE;
+                }
+                [$new, $updated] = $qiita->fetchByTag($value);
                 break;
 
             default:
-                $this->error('Unknown target: ' . $target);
+                $this->error('Unknown target: ' . $type);
                 return Command::FAILURE;
         }
 
-        $this->info("Fetched successfully: new={$new}, updated={$updated}, skipped={$skipped}");
+        $this->info("Fetched successfully: new={$new}, updated={$updated}");
         return Command::SUCCESS;
     }
 }

--- a/src/app/Services/ArticleFetcher/QiitaFetcher.php
+++ b/src/app/Services/ArticleFetcher/QiitaFetcher.php
@@ -9,10 +9,12 @@ class QiitaFetcher
 {
     private string $baseUrl = 'https://qiita.com/api/v2/items';
     private string $defaultQiitaThumbnail;
+    private Source $source;
 
     public function __construct()
     {
         $this->defaultQiitaThumbnail = url('images/qiita.png');
+        $this->source = Source::where('name', 'Qiita')->first();
     }
 
     // 新着記事
@@ -28,11 +30,6 @@ class QiitaFetcher
     // 人気記事
     public function fetchPopular(): array
     {
-        $new = 0;
-        $updated = 0;
-        $skipped = 0;
-        $source = Source::where('name', 'Qiita')->first();
-
         $mergedItems = [];
 
         // Qiita API は page 1〜100 まで
@@ -46,7 +43,7 @@ class QiitaFetcher
             ]);
 
             if ($response->failed()) {
-                break;
+                throw new \RuntimeException("Qiita API Error: " . $response->status());
             }
 
             $items = $response->json();
@@ -58,27 +55,7 @@ class QiitaFetcher
         }
 
         // まとめて保存
-        foreach ($mergedItems as $item) {
-            $article = Article::updateOrCreate(
-                [
-                    'source_id' => $source->id,
-                    'source_item_id' => $item['id'],
-                ],
-                [
-                    'url' => $item['url'],
-                    'title' => $item['title'],
-                    'author_name' => $item['user']['id'] ?? null,
-                    'thumbnail_url' => $this->defaultQiitaThumbnail,
-                    'source_like_count' => $item['likes_count'] ?? 0,
-                    'pubished_at' => $item['created_at'],
-                    'fetched_at' => now(),
-                ]
-            );
-
-            $article->wasRecentlyCreated ? $new++ : $updated++;
-        }
-
-        return [$new, $updated, $skipped];
+        return $this->fetchFromApi($mergedItems);
     }
 
     // カテゴリ別記事
@@ -91,27 +68,28 @@ class QiitaFetcher
         ]);
     }
 
-    // APIアクセス＋保存
+    // APIアクセス
     public function fetchFromApi(array $params): array
     {
-        $new = 0;
-        $updated = 0;
-        $skipped = 0;
-
         $response = HTTP::get($this->baseUrl, $params);
 
         if ($response->failed()) {
             throw new \RuntimeException('Qiita API error:' . $response->status());
         }
 
-        $items = $response->json();
-        $source = Source::where('name', 'Qiita')->first();
+        return $this->saveArticles($response->json());
+    }
 
-        // すでに取得済みのデータは更新・新規取得は登録
+    // 記事保存
+    public function saveArticles(array $items): array
+    {
+        $new = 0;
+        $updated = 0;
+
         foreach ($items as $item) {
             $article = Article::updateOrCreate(
                 [
-                    'source_id' => $source->id,
+                    'source_id' => $this->source->id,
                     'source_item_id' => $item['id'],
                 ],
                 [
@@ -128,6 +106,6 @@ class QiitaFetcher
             $article->wasRecentlyCreated ? $new++ : $updated++;
         }
 
-        return [$new, $updated, $skipped];
+        return [$new, $updated];
     }
 }

--- a/src/app/Services/ArticleFetcher/QiitaFetcher.php
+++ b/src/app/Services/ArticleFetcher/QiitaFetcher.php
@@ -4,6 +4,8 @@ namespace App\Services\ArticleFetcher;
 use Illuminate\Support\Facades\Http;
 use App\Models\Article;
 use App\Models\Source;
+use App\Models\Category;
+use App\Models\ArticleCategory;
 
 class QiitaFetcher
 {
@@ -103,9 +105,30 @@ class QiitaFetcher
                 ]
             );
 
+            $this->saveArticleCategory($item, $article);
+
             $article->wasRecentlyCreated ? $new++ : $updated++;
         }
 
         return [$new, $updated];
+    }
+
+    // カテゴリ紐づけ
+    public function saveArticleCategory($item, $article)
+    {
+        $tags = $item['tags'] ?? [];
+
+        foreach ($tags as $tag) {
+            $category = Category::where('slug', $tag['name'])
+                ->where('name', $tag['name'])
+                ->first();
+
+            if (isset($category)) {
+                ArticleCategory::create([
+                    'article_id' => $article['id'],
+                    'category_id' => $category['id'],
+                ]);
+            }
+        }
     }
 }


### PR DESCRIPTION
## 概要
Qitta取得機能のリファクタリングとカテゴリと紐づけ機能追加
## 内容
メソッドことの処理を一つの処理だけに変更
jsonからitemsを取得し、itemsからnameをとりカテゴリと紐づけ
```
root@bdd2950152ce:/app# php artisan fetch:qitta tag react
Fetched successfully: new=20, updated=0
```
<img width="820" height="543" alt="image" src="https://github.com/user-attachments/assets/7ad20071-1977-4f51-8df3-6a3dff6be23e" />
