### PR TITLE
記事を自動取得できる機能を追加

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -74,9 +74,26 @@ services:
     ports:
       - 8025:8025
       - 1025:1025
+
+  cron:
+    container_name: tech-cron
+    build: ./docker/cron
+    volumes:
+      - ./src:/app
+      - ./docker/cron/laravel-cron:/etc/cron.d/laravel-cron
+    entrypoint: [
+      "bash", "-c",
+      "chmod 0644 /etc/cron.d/laravel-cron &&
+      cron &&
+      tail -f /var/log/cron.log"
+    ]
+    networks:
+      - appnet  
+    restart: unless-stopped
+
 volumes:
   dbdata:
-
+  
 networks:
   appnet:
     driver: bridge

--- a/docker/cron/Dockerfile
+++ b/docker/cron/Dockerfile
@@ -1,0 +1,9 @@
+FROM php:8.2-cli
+
+RUN apt-get update && \
+    apt-get install -y cron procps && \
+    docker-php-ext-install pdo pdo_mysql && \
+    touch /var/log/cron.log && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app

--- a/docker/cron/laravel-cron
+++ b/docker/cron/laravel-cron
@@ -1,0 +1,1 @@
+* * * * * root cd /app && /usr/local/bin/php artisan schedule:run >> /var/log/cron.log 2>&1

--- a/src/app/Console/Kernel.php
+++ b/src/app/Console/Kernel.php
@@ -15,12 +15,10 @@ class Kernel extends ConsoleKernel
      */
     protected function schedule(Schedule $schedule)
     {
-        $schedule->command('articles:fetch qiita:new')->daily();
-        $schedule->command('articles:fetch qiita:popular')->weekly();
-        $schedule->command('articles:fetch qiita:popular')->weekly();
-        $schedule->command('articles:fetch qiita:tag:react')->daily();
-        $schedule->command('articles:fetch qiita:tag:laravel')->daily();
-        $schedule->command('articles:fetch qiita:tag:javascrpit')->daily();
+        $schedule->command('fetch:qitta popular')->weekly();
+        $schedule->command('fetch:qitta tag react')->daily();
+        $schedule->command('fetch:qitta tag laravel')->daily();
+        $schedule->command('fetch:qitta tag javascrpit')->daily();
         $schedule->command('fetch:zenn new')->daily()->appendOutputTo(storage_path('logs/zenn.log'));
         $schedule->command('fetch:zenn popular weekly')->weekly()->appendOutputTo(storage_path('logs/zenn.log'));
         $schedule->command('fetch:zenn popular alltime')->monthly()->appendOutputTo(storage_path('logs/zenn.log'));


### PR DESCRIPTION
## 概要
cronを用いて、記事を自動取得できる機能の作成
## 内容
DockerFileでcronをインストールし、crontabを使用して、アプリ内のスケジューラーを自動で実行する機能を作成しました。