### PR TITLE
カテゴリ詳細apiの作成

### DIFF
--- a/src/app/Http/Controllers/CategoryController.php
+++ b/src/app/Http/Controllers/CategoryController.php
@@ -3,15 +3,49 @@
 namespace App\Http\Controllers;
 use App\Models\Category;
 use App\Http\Resources\CategoryResource;
+use App\Http\Resources\HomeResource;
 use Illuminate\Http\Request;
+use App\Http\Requests\CategoryRequest;
+use App\Services\CategoryService;
 
 class CategoryController extends Controller
 {
+
+    public function __construct(
+        private CategoryService $categoryService
+    ) {
+    }
+
     public function index()
     {
         try {
             return response()->json([
                 'categories' => CategoryResource::collection(Category::all()),
+            ]);
+        } catch (\Exception $e) {
+            \Illuminate\Support\Facades\Log::error($e);
+            return response()->json(['message' => 'サーバーエラーが発生しました。'], 500);
+        }
+    }
+
+    public function show(CategoryRequest $req)
+    {
+        $defaultPage = 1;
+
+        try {
+            $user = auth()->user();
+            $category = Category::slug($req->slug)->firstOrFail();
+            $page = $req->input('page', $defaultPage);
+
+            $articles = $this->categoryService->getArticlesByCategory(
+                $category,
+                $user,
+                $page,
+            );
+
+            return response()->json([
+                'category' => CategoryResource::make($category),
+                'articles' => HomeResource::collection($articles)->response()->getData(true),
             ]);
         } catch (\Exception $e) {
             \Illuminate\Support\Facades\Log::error($e);

--- a/src/app/Http/Controllers/CategoryController.php
+++ b/src/app/Http/Controllers/CategoryController.php
@@ -47,6 +47,8 @@ class CategoryController extends Controller
                 'category' => CategoryResource::make($category),
                 'articles' => HomeResource::collection($articles)->response()->getData(true),
             ]);
+        } catch (\Illuminate\Database\Eloquent\ModelNotFoundException $e) {
+            return response()->json(['message' => 'カテゴリが見つかりません。'], 404);
         } catch (\Exception $e) {
             \Illuminate\Support\Facades\Log::error($e);
             return response()->json(['message' => 'サーバーエラーが発生しました。'], 500);

--- a/src/app/Http/Requests/CategoryRequest.php
+++ b/src/app/Http/Requests/CategoryRequest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class CategoryRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    protected function prepareForValidation()
+    {
+        $this->merge([
+            'slug' => strtolower(trim($this->slug)),
+        ]);
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules()
+    {
+        return [
+            'slug' => [
+                'required',
+                'string',
+                'max:255',
+                'exists:categories,slug',
+            ],
+            'page' => [
+                'nullable', 
+                'integer',
+                'min:1', 
+            ],
+        ];
+    }
+
+}

--- a/src/app/Http/Resources/CategoryResource.php
+++ b/src/app/Http/Resources/CategoryResource.php
@@ -17,6 +17,7 @@ class CategoryResource extends JsonResource
         return [
             'id' => $this->id,
             'name' => $this->name,
+            'slug'=> $this->slug,
             'iconUrl' => $this->icon_url
                 ? asset($this->icon_url)
                 : null,

--- a/src/app/Models/Category.php
+++ b/src/app/Models/Category.php
@@ -14,9 +14,14 @@ class Category extends Model
         'slug'
     ];
 
-     public function articleCategory()
+    public function articleCategory()
     {
         return $this->hasMany(ArticleCategory::class);
     }
-    
+
+    public function scopeSlug($query, $slug)
+    {
+        return $query->where('slug', $slug);
+    }
+
 }

--- a/src/app/Services/CategoryService.php
+++ b/src/app/Services/CategoryService.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Category;
+use App\Models\User;
+use App\Models\Article;
+
+class CategoryService
+{
+    public function getArticlesByCategory(Category $category, ?User $user, int $page)
+    {
+        return Article::query()
+            ->with([
+                'source',
+                'categories',
+                'bookmarks' => fn($q) => $q->where('user_id', $user?->id),
+            ])
+            ->whereHas(
+                'categories',
+                fn($q) =>
+                $q->where('categories.id', $category->id)
+            )
+            ->orderByDesc('source_like_count')
+            ->paginate(6, ['*'], 'page', $page);
+    }
+}

--- a/src/app/Services/CategoryService.php
+++ b/src/app/Services/CategoryService.php
@@ -8,6 +8,7 @@ use App\Models\Article;
 
 class CategoryService
 {
+    private const ARTICLES_PER_PAGE = 6;
     public function getArticlesByCategory(Category $category, ?User $user, int $page)
     {
         return Article::query()
@@ -22,6 +23,6 @@ class CategoryService
                 $q->where('categories.id', $category->id)
             )
             ->orderByDesc('source_like_count')
-            ->paginate(6, ['*'], 'page', $page);
+            ->paginate(self::ARTICLES_PER_PAGE, ['*'], 'page', $page);
     }
 }

--- a/src/routes/api.php
+++ b/src/routes/api.php
@@ -26,3 +26,4 @@ Route::middleware('optional.auth')->group(function () {
 });
 
 Route::get('/categories', [CategoryController::class, 'index']);
+Route::get('/categories/{slug}', [CategoryController::class, 'show']);

--- a/src/routes/api.php
+++ b/src/routes/api.php
@@ -23,7 +23,6 @@ Route::middleware('auth.token')->group(function () {
 
 Route::middleware('optional.auth')->group(function () {
     Route::get('/home', [HomeController::class, 'index']);
+    Route::get('/categories', [CategoryController::class, 'index']);
+    Route::get('/categories/{slug}', [CategoryController::class, 'show']);
 });
-
-Route::get('/categories', [CategoryController::class, 'index']);
-Route::get('/categories/{slug}', [CategoryController::class, 'show']);


### PR DESCRIPTION
## 変更の概要
カテゴリ詳細apiの作成
## なぜこの変更をするのか
カテゴリごとの記事を取得するため
## やったこと
カテゴリのslugを基に記事を取得する
paginateでページを管理
## 変更内容
<img width="1295" height="869" alt="image" src="https://github.com/user-attachments/assets/eaee1112-57b1-4287-a436-e1a1a8bcae27" />