### PR TITLE
履歴一覧画面のAPIを作成

### DIFF
--- a/src/app/Http/Controllers/Me/MeViewController.php
+++ b/src/app/Http/Controllers/Me/MeViewController.php
@@ -3,25 +3,26 @@
 namespace App\Http\Controllers\Me;
 
 use App\Http\Controllers\Controller;
-use App\Services\BookmarkService;
-use App\Http\Requests\BookmarkRequest;
+use App\Http\Requests\ViewRequest;
+use App\Services\ViewService;
 use App\Http\Resources\HomeResource;
 use Illuminate\Support\Facades\Log;
 
-class MeBookmarkController extends Controller
+
+class MeViewController extends Controller
 {
     public function __construct(
-        private BookmarkService $bookmarkService
+        private ViewService $viewService
     ) {
     }
-    public function index(BookmarkRequest $req)
+    public function index(ViewRequest $req)
     {
         try {
             $validated = $req->validated();
             $page = $validated['page'] ?? 1;
             $user = auth()->user();
             $page = $req->input('page', $page);
-            $articles = $this->bookmarkService->getBookmark($user, $page);
+            $articles = $this->viewService->getviews($user, $page);
 
             return response()->json(
                 ['articles' => HomeResource::collection($articles)->response()->getData(true)],
@@ -31,5 +32,4 @@ class MeBookmarkController extends Controller
             return response()->json(['message' => 'サーバーエラーが発生しました。'], 500);
         }
     }
-
 }

--- a/src/app/Http/Controllers/Me/MeViewController.php
+++ b/src/app/Http/Controllers/Me/MeViewController.php
@@ -21,8 +21,7 @@ class MeViewController extends Controller
             $validated = $req->validated();
             $page = $validated['page'] ?? 1;
             $user = auth()->user();
-            $page = $req->input('page', $page);
-            $articles = $this->viewService->getviews($user, $page);
+            $articles = $this->viewService->getViews($user, $page);
 
             return response()->json(
                 ['articles' => HomeResource::collection($articles)->response()->getData(true)],

--- a/src/app/Http/Requests/BookmarkRequest.php
+++ b/src/app/Http/Requests/BookmarkRequest.php
@@ -4,7 +4,7 @@ namespace App\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
 
-class BookmarkIndexRequest extends FormRequest
+class BookmarkRequest extends FormRequest
 {
     /**
      * Determine if the user is authorized to make this request.

--- a/src/app/Http/Requests/ViewRequest.php
+++ b/src/app/Http/Requests/ViewRequest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ViewRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules()
+    {
+        return [
+            'page' => [
+                'nullable',
+                'integer',
+                'min:1',
+            ],
+        ];
+    }
+}

--- a/src/app/Models/User.php
+++ b/src/app/Models/User.php
@@ -59,6 +59,16 @@ class User extends Authenticatable
         );
     }
 
+    public function views()
+    {
+        return $this->belongsToMany(
+            Article::class,
+            'article_views',
+            'user_id',
+            'article_id',
+        );
+    }
+
     public function createUser($name, $email, $password)
     {
         $this->name = $name;

--- a/src/app/Models/User.php
+++ b/src/app/Models/User.php
@@ -66,7 +66,7 @@ class User extends Authenticatable
             'article_views',
             'user_id',
             'article_id',
-        );
+        )->withPivot('last_viewed_at');
     }
 
     public function createUser($name, $email, $password)

--- a/src/app/Services/ViewService.php
+++ b/src/app/Services/ViewService.php
@@ -23,7 +23,7 @@ class ViewService
     public function getViews(User $user, int $page)
     {
         return $user->views()
-            ->with(['source', 'categories'])
+            ->with(['source', 'categories', 'bookmarks' => fn($query) => $query->where('user_id', $user->id)])
             ->orderByDesc('article_views.last_viewed_at')
             ->paginate(self::ARTICLES_PER_PAGE, ['*'], 'page', $page);
     }

--- a/src/app/Services/ViewService.php
+++ b/src/app/Services/ViewService.php
@@ -6,6 +6,7 @@ use App\Models\ArticleView;
 
 class ViewService
 {
+    private const ARTICLES_PER_PAGE = 9;
     public function viewHistory(User $user, int $articleId)
     {
         ArticleView::updateOrCreate(
@@ -17,5 +18,13 @@ class ViewService
                 'last_viewed_at' => now(),
             ]
         );
+    }
+
+    public function getViews(User $user, int $page)
+    {
+        return $user->views()
+            ->with(['source', 'categories'])
+            ->orderByDesc('article_views.last_viewed_at')
+            ->paginate(self::ARTICLES_PER_PAGE, ['*'], 'page', $page);
     }
 }

--- a/src/routes/api.php
+++ b/src/routes/api.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\HomeController;
 use App\Http\Controllers\CategoryController;
 use App\Http\Controllers\ArticleViewController;
 use App\Http\Controllers\Me\MeBookmarkController;
+use App\Http\Controllers\Me\MeViewController;
 
 /*
 |--------------------------------------------------------------------------
@@ -26,6 +27,7 @@ Route::middleware('auth.token')->group(function () {
     Route::delete('/articles/{article}/bookmark', [ArticleBookmarkController::class, 'destroy']);
     Route::post('/articles/{article}/view', [ArticleViewController::class, 'store']);
     Route::get('me/bookmarks', [MeBookmarkController::class, 'index']);
+    Route::get('me/views', [MeViewController::class, 'index']);
 });
 
 Route::middleware('optional.auth')->group(function () {


### PR DESCRIPTION
## 変更の概要
履歴一覧画面のAPIを作成

## なぜこの変更をするのか
ユーザーが記事の履歴を見返すときに一覧で表示したいため

## やったこと
user と article を、article_viewsを通して結びつける
views()からuser_idに紐づくデータを取得して、関連するリレーションも取得
## 変更内容
<img width="1261" height="842" alt="image" src="https://github.com/user-attachments/assets/4eb6833e-e7ec-45db-ab1a-b7f1906a22ed" />